### PR TITLE
Feat/joy con

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,18 +8,55 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@react-three/drei": "^10.7.8",
+        "@react-three/fiber": "^9.7.0",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
-        "react-router-dom": "^7.18.2"
+        "react-router-dom": "^7.18.2",
+        "three": "^0.185.1"
       },
       "devDependencies": {
         "@types/node": "^24.13.3",
         "@types/react": "^19.2.18",
         "@types/react-dom": "^19.2.4",
+        "@types/three": "^0.185.4",
         "@vitejs/plugin-react": "^6.1.0",
         "oxlint": "^1.79.0",
         "typescript": "~6.0.2",
         "vite": "^8.2.2"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@mediapipe/tasks-vision": {
+      "version": "0.10.17",
+      "resolved": "https://registry.npmjs.org/@mediapipe/tasks-vision/-/tasks-vision-0.10.17.tgz",
+      "integrity": "sha512-CZWV/q6TTe8ta61cZXjfnnHsfWIdFhms03M9T7Cnd5y2mdpylJM0rF1qRq+wsQVRMLz1OYPVEBU9ph2Bx8cxrg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@monogrid/gainmap-js": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@monogrid/gainmap-js/-/gainmap-js-3.4.0.tgz",
+      "integrity": "sha512-2Z0FATFHaoYJ8b+Y4y4Hgfn3FRFwuU5zRrk+9dFWp4uGAdHGqVEdP7HP+gLA3X469KXHmfupJaUbKo1b/aDKIg==",
+      "license": "MIT",
+      "dependencies": {
+        "promise-worker-transferable": "^1.0.4"
+      },
+      "peerDependencies": {
+        "three": ">= 0.159.0"
       }
     },
     "node_modules/@oxc-project/types": {
@@ -355,6 +392,94 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
+    "node_modules/@react-three/drei": {
+      "version": "10.7.8",
+      "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-10.7.8.tgz",
+      "integrity": "sha512-rJXyuzLm2Xq0kafHuR47ajDGbOe/pEhzIr4m8E8zwzQs0iNjloFDqBwRhrXmP/w+onLeYyN3EYPFW/cwWK/4yA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0",
+        "@mediapipe/tasks-vision": "0.10.17",
+        "@monogrid/gainmap-js": "^3.0.6",
+        "@use-gesture/react": "^10.3.1",
+        "camera-controls": "^3.1.0",
+        "cross-env": "^7.0.3",
+        "detect-gpu": "^5.0.56",
+        "glsl-noise": "^0.0.0",
+        "hls.js": "^1.5.17",
+        "maath": "^0.10.8",
+        "meshline": "^3.3.1",
+        "stats-gl": "^2.2.8",
+        "stats.js": "^0.17.0",
+        "suspend-react": "^0.1.3",
+        "three-mesh-bvh": "^0.8.3",
+        "three-stdlib": "^2.35.6",
+        "troika-three-text": "^0.52.4",
+        "tunnel-rat": "^0.1.2",
+        "use-sync-external-store": "^1.4.0",
+        "utility-types": "^3.11.0",
+        "zustand": "^5.0.1"
+      },
+      "peerDependencies": {
+        "@react-three/fiber": "^9.0.0",
+        "react": "^19",
+        "react-dom": "^19",
+        "three": ">=0.159"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-three/fiber": {
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.7.0.tgz",
+      "integrity": "sha512-EWm9FwcaOZQu/ExFW5rggoCMM1NJet5YbxVxKaOE+KSncrjU0Wx7017qSyGFvupviK89nMYGCWU3BIK4dI1clw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.17.8",
+        "@types/webxr": "*",
+        "base64-js": "^1.5.1",
+        "buffer": "^6.0.3",
+        "its-fine": "^2.0.0",
+        "react-use-measure": "^2.1.7",
+        "scheduler": "^0.27.0",
+        "suspend-react": "^0.1.3",
+        "use-sync-external-store": "^1.4.0",
+        "zustand": "^5.0.3"
+      },
+      "peerDependencies": {
+        "expo": ">=43.0",
+        "expo-asset": ">=8.4",
+        "expo-file-system": ">=11.0",
+        "expo-gl": ">=11.0",
+        "react": ">=19 <19.3",
+        "react-dom": ">=19 <19.3",
+        "react-native": ">=0.78",
+        "three": ">=0.156"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "expo-asset": {
+          "optional": true
+        },
+        "expo-file-system": {
+          "optional": true
+        },
+        "expo-gl": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rolldown/binding-android-arm-eabi": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.5.tgz",
@@ -617,6 +742,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/draco3d": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@types/draco3d/-/draco3d-1.4.10.tgz",
+      "integrity": "sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "24.13.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
@@ -627,11 +764,16 @@
         "undici-types": "~7.18.0"
       }
     },
+    "node_modules/@types/offscreencanvas": {
+      "version": "2019.7.3",
+      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
+      "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==",
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
       "version": "19.2.18",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
       "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -645,6 +787,59 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/react-reconciler": {
+      "version": "0.28.9",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
+      "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.185.4",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.185.4.tgz",
+      "integrity": "sha512-gAsBIC07NIFrxjbf7tH2t71c38uulFfk/RFoC7FNBSjMRAQ8J1x/RBvusX0N5PJouaYFJawXQqfCQ0RKUx/1nA==",
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": ">=0.5.17",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~1.1.1"
+      }
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+      "license": "MIT"
+    },
+    "node_modules/@use-gesture/core": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
+      "integrity": "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==",
+      "license": "MIT"
+    },
+    "node_modules/@use-gesture/react": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.3.1.tgz",
+      "integrity": "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@use-gesture/core": "10.3.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -677,6 +872,72 @@
         }
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/camera-controls": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/camera-controls/-/camera-controls-3.1.2.tgz",
+      "integrity": "sha512-xkxfpG2ECZ6Ww5/9+kf4mfg1VEYAoe9aDSY+IwF0UEs7qEzwy0aVRfs2grImIECs/PoBtWFrh7RXsQkwG922JA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.0.0",
+        "npm": ">=10.5.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.126.1"
+      }
+    },
     "node_modules/cookie": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
@@ -690,12 +951,52 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/detect-gpu": {
+      "version": "5.0.70",
+      "resolved": "https://registry.npmjs.org/detect-gpu/-/detect-gpu-5.0.70.tgz",
+      "integrity": "sha512-bqerEP1Ese6nt3rFkwPnGbsUF9a4q+gMmpTVVOEzoCyeCc+y7/RvJnQZJx1JwhgQI5Ntg0Kgat8Uu7XpBqnz1w==",
+      "license": "MIT",
+      "dependencies": {
+        "webgl-constants": "^1.1.1"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -706,6 +1007,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/draco3d": {
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.5.7.tgz",
+      "integrity": "sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -725,6 +1032,12 @@
         }
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -738,6 +1051,77 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glsl-noise": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/glsl-noise/-/glsl-noise-0.0.0.tgz",
+      "integrity": "sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w==",
+      "license": "MIT"
+    },
+    "node_modules/hls.js": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.7.1.tgz",
+      "integrity": "sha512-DlzIkeBAS9IIQ432k3BUf3HlwbsR0+trB1i2lDdN2gUkNkrehFurh0/48M5c1/EjlDkdGng1gwZIpwyPxvdZ/g==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/its-fine": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-2.0.0.tgz",
+      "integrity": "sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-reconciler": "^0.28.9"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lightningcss": {
@@ -1001,6 +1385,31 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/maath": {
+      "version": "0.10.8",
+      "resolved": "https://registry.npmjs.org/maath/-/maath-0.10.8.tgz",
+      "integrity": "sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/three": ">=0.134.0",
+        "three": ">=0.134.0"
+      }
+    },
+    "node_modules/meshline": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/meshline/-/meshline-3.3.1.tgz",
+      "integrity": "sha512-/TQj+JdZkeSUOl5Mk2J7eLcYTLiQm2IDzmlSvYm7ov15anEcDJ92GHqqazxTSreeNgfnYu24kiEvvv0WlbCdFQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.137"
+      }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.1.1.tgz",
+      "integrity": "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==",
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.18",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
@@ -1069,6 +1478,15 @@
         }
       }
     },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1116,6 +1534,22 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/potpack": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
+      "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==",
+      "license": "ISC"
+    },
+    "node_modules/promise-worker-transferable": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/promise-worker-transferable/-/promise-worker-transferable-1.0.4.tgz",
+      "integrity": "sha512-bN+0ehEnrXfxV2ZQvU2PetO0n4gqBD4ulq3MI1WOPLgr7/Mg9yRQkX5+0v1vagr74ZTsl7XtzlaYDo2EuCeYJw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "is-promise": "^2.1.0",
+        "lie": "^3.0.2"
       }
     },
     "node_modules/react": {
@@ -1177,6 +1611,30 @@
         "react-dom": ">=18"
       }
     },
+    "node_modules/react-use-measure": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.7.tgz",
+      "integrity": "sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.13",
+        "react-dom": ">=16.13"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rolldown": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.5.tgz",
@@ -1223,6 +1681,27 @@
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1232,6 +1711,79 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stats-gl": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/stats-gl/-/stats-gl-2.4.2.tgz",
+      "integrity": "sha512-g5O9B0hm9CvnM36+v7SFl39T7hmAlv541tU81ME8YeSb3i1CIP5/QdDeSB3A0la0bKNHpxpwxOVRo2wFTYEosQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/three": "*",
+        "three": "^0.170.0"
+      },
+      "peerDependencies": {
+        "@types/three": "*",
+        "three": "*"
+      }
+    },
+    "node_modules/stats-gl/node_modules/three": {
+      "version": "0.170.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.170.0.tgz",
+      "integrity": "sha512-FQK+LEpYc0fBD+J8g6oSEyyNzjp+Q7Ks1C568WWaoMRLW+TkNNWmenWeGgJjV105Gd+p/2ql1ZcjYvNiPZBhuQ==",
+      "license": "MIT"
+    },
+    "node_modules/stats.js": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/stats.js/-/stats.js-0.17.0.tgz",
+      "integrity": "sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==",
+      "license": "MIT"
+    },
+    "node_modules/suspend-react": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/suspend-react/-/suspend-react-0.1.3.tgz",
+      "integrity": "sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=17.0"
+      }
+    },
+    "node_modules/three": {
+      "version": "0.185.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.185.1.tgz",
+      "integrity": "sha512-5aojFCXKwnjBRZvUnt3WFfEcvUJgkN5LlijRFN95hMy8WVkG4I0QNcJE+OuWvuJ0bOdStrbfXn0pkd6/QyiAlg==",
+      "license": "MIT"
+    },
+    "node_modules/three-mesh-bvh": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.8.3.tgz",
+      "integrity": "sha512-4G5lBaF+g2auKX3P0yqx+MJC6oVt6sB5k+CchS6Ob0qvH0YIhuUk1eYr7ktsIpY+albCqE80/FVQGV190PmiAg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">= 0.159.0"
+      }
+    },
+    "node_modules/three-stdlib": {
+      "version": "2.36.1",
+      "resolved": "https://registry.npmjs.org/three-stdlib/-/three-stdlib-2.36.1.tgz",
+      "integrity": "sha512-XyGQrFmNQ5O/IoKm556ftwKsBg11TIb301MB5dWNicziQBEs2g3gtOYIf7pFiLa0zI2gUwhtCjv9fmjnxKZ1Cg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/draco3d": "^1.4.0",
+        "@types/offscreencanvas": "^2019.6.4",
+        "@types/webxr": "^0.5.2",
+        "draco3d": "^1.4.1",
+        "fflate": "^0.6.9",
+        "potpack": "^1.0.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.128.0"
+      }
+    },
+    "node_modules/three-stdlib/node_modules/fflate": {
+      "version": "0.6.11",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.6.11.tgz",
+      "integrity": "sha512-3JyEFWGjFn7zHmoa9+zG1BmW7X2okcmAB+0Cnu9UFbVs/jCBnl2A8o065ZlXiw145K3eBM3uLuzrYXC0RK7eDg==",
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
@@ -1248,6 +1800,73 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/troika-three-text": {
+      "version": "0.52.5",
+      "resolved": "https://registry.npmjs.org/troika-three-text/-/troika-three-text-0.52.5.tgz",
+      "integrity": "sha512-Ry3jRhic9pzcY4JduSvRRyDmVOSqEW19gT4vtK+aCiPNVcDlmkxvGG0YbFd36RTDq1wExOupXnvNF/j1oiHHDA==",
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.2",
+        "troika-three-utils": "^0.52.5",
+        "troika-worker-utils": "^0.52.0",
+        "webgl-sdf-generator": "1.1.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.125.0"
+      }
+    },
+    "node_modules/troika-three-utils": {
+      "version": "0.52.5",
+      "resolved": "https://registry.npmjs.org/troika-three-utils/-/troika-three-utils-0.52.5.tgz",
+      "integrity": "sha512-WsePbcX8RtfidRfsxK1eCZCjF81ZDzAKHH/evLs0hdV2wpoCb0vArGZHdzdOJrSS3k4zfdtbKDaBh8+phkrYnw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.125.0"
+      }
+    },
+    "node_modules/troika-worker-utils": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/troika-worker-utils/-/troika-worker-utils-0.52.0.tgz",
+      "integrity": "sha512-W1CpvTHykaPH5brv5VHLfQo9D1OYuo0cSBEUQFFT/nBUzM8iD6Lq2/tgG/f1OelbAS1WtaTPQzE5uM49egnngw==",
+      "license": "MIT"
+    },
+    "node_modules/tunnel-rat": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tunnel-rat/-/tunnel-rat-0.1.2.tgz",
+      "integrity": "sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "zustand": "^4.3.2"
+      }
+    },
+    "node_modules/tunnel-rat/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/typescript": {
@@ -1270,6 +1889,24 @@
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/utility-types": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.11.0.tgz",
+      "integrity": "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/vite": {
       "version": "8.2.2",
@@ -1345,6 +1982,61 @@
           "optional": true
         },
         "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webgl-constants": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-constants/-/webgl-constants-1.1.1.tgz",
+      "integrity": "sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg=="
+    },
+    "node_modules/webgl-sdf-generator": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-sdf-generator/-/webgl-sdf-generator-1.1.1.tgz",
+      "integrity": "sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA==",
+      "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.15",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.15.tgz",
+      "integrity": "sha512-MpSEjRiBkA9crSYeOUH32rJC7SVqAbm0Fqcqge/bUi2PPoLcBWKOsG+C8mevmpr8TwXHBVkChbbJiyvkE+i/3A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
           "optional": true
         }
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,14 +10,18 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@react-three/drei": "^10.7.8",
+    "@react-three/fiber": "^9.7.0",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
-    "react-router-dom": "^7.18.2"
+    "react-router-dom": "^7.18.2",
+    "three": "^0.185.1"
   },
   "devDependencies": {
     "@types/node": "^24.13.3",
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",
+    "@types/three": "^0.185.4",
     "@vitejs/plugin-react": "^6.1.0",
     "oxlint": "^1.79.0",
     "typescript": "~6.0.2",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import { Route, Routes } from 'react-router-dom'
+import { JoyConProvider } from './contexts/JoyConContext'
 import ConnectPage from './pages/ConnectPage'
 import GamePage from './pages/GamePage'
 import RankingPage from './pages/RankingPage'
@@ -7,13 +8,15 @@ import TitlePage from './pages/TitlePage'
 
 function App() {
   return (
-    <Routes>
-      <Route path="/" element={<TitlePage />} />
-      <Route path="/connect" element={<ConnectPage />} />
-      <Route path="/game" element={<GamePage />} />
-      <Route path="/result" element={<ResultPage />} />
-      <Route path="/ranking" element={<RankingPage />} />
-    </Routes>
+    <JoyConProvider>
+      <Routes>
+        <Route path="/" element={<TitlePage />} />
+        <Route path="/connect" element={<ConnectPage />} />
+        <Route path="/game" element={<GamePage />} />
+        <Route path="/result" element={<ResultPage />} />
+        <Route path="/ranking" element={<RankingPage />} />
+      </Routes>
+    </JoyConProvider>
   )
 }
 

--- a/frontend/src/components/three/Lightsaber.tsx
+++ b/frontend/src/components/three/Lightsaber.tsx
@@ -1,0 +1,38 @@
+import { useFrame } from '@react-three/fiber'
+import { useRef } from 'react'
+import type { Group } from 'three'
+import type { JoyConVector3 } from '../../lib/joycon/joyConDevice'
+
+interface LightsaberProps {
+  gyro: JoyConVector3 | null
+}
+
+const DEG_TO_RAD = Math.PI / 180
+
+function Lightsaber({ gyro }: LightsaberProps) {
+  const groupRef = useRef<Group>(null)
+
+  useFrame((_, delta) => {
+    if (!gyro || !groupRef.current) return
+    // ジャイロの角速度(deg/s)をそのまま積分して姿勢を更新する簡易実装。
+    // ドリフトは考慮していないため、長時間振り続けると姿勢がずれていく。
+    groupRef.current.rotation.x += gyro.x * DEG_TO_RAD * delta
+    groupRef.current.rotation.y += gyro.y * DEG_TO_RAD * delta
+    groupRef.current.rotation.z += gyro.z * DEG_TO_RAD * delta
+  })
+
+  return (
+    <group ref={groupRef}>
+      <mesh position={[0, -0.6, 0]}>
+        <cylinderGeometry args={[0.02, 0.02, 0.2, 16]} />
+        <meshStandardMaterial color="#888888" />
+      </mesh>
+      <mesh position={[0, 0.4, 0]}>
+        <cylinderGeometry args={[0.015, 0.015, 1.2, 16]} />
+        <meshStandardMaterial color="#4cc9f0" emissive="#4cc9f0" emissiveIntensity={2} toneMapped={false} />
+      </mesh>
+    </group>
+  )
+}
+
+export default Lightsaber

--- a/frontend/src/components/three/LightsaberScene.tsx
+++ b/frontend/src/components/three/LightsaberScene.tsx
@@ -1,0 +1,19 @@
+import { Canvas } from '@react-three/fiber'
+import type { JoyConVector3 } from '../../lib/joycon/joyConDevice'
+import Lightsaber from './Lightsaber'
+
+interface LightsaberSceneProps {
+  gyro: JoyConVector3 | null
+}
+
+function LightsaberScene({ gyro }: LightsaberSceneProps) {
+  return (
+    <Canvas camera={{ position: [0, 0, 4], fov: 50 }} style={{ width: '100%', height: '480px' }}>
+      <ambientLight intensity={0.6} />
+      <pointLight position={[2, 2, 2]} intensity={1} />
+      <Lightsaber gyro={gyro} />
+    </Canvas>
+  )
+}
+
+export default LightsaberScene

--- a/frontend/src/contexts/JoyConContext.tsx
+++ b/frontend/src/contexts/JoyConContext.tsx
@@ -1,0 +1,17 @@
+import { createContext, useContext, type ReactNode } from 'react'
+import { useJoyCon, type UseJoyConResult } from '../hooks/useJoyCon'
+
+const JoyConContext = createContext<UseJoyConResult | null>(null)
+
+export function JoyConProvider({ children }: { children: ReactNode }) {
+  const joyCon = useJoyCon()
+  return <JoyConContext.Provider value={joyCon}>{children}</JoyConContext.Provider>
+}
+
+export function useJoyConContext(): UseJoyConResult {
+  const context = useContext(JoyConContext)
+  if (!context) {
+    throw new Error('useJoyConContext must be used within a JoyConProvider')
+  }
+  return context
+}

--- a/frontend/src/hooks/useJoyCon.ts
+++ b/frontend/src/hooks/useJoyCon.ts
@@ -1,0 +1,41 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { JoyCon, requestJoyCon, type JoyConState } from '../lib/joycon/joyConDevice'
+
+export interface UseJoyConResult {
+  isSupported: boolean
+  isConnected: boolean
+  state: JoyConState | null
+  error: string | null
+  connect: () => Promise<void>
+}
+
+export function useJoyCon(): UseJoyConResult {
+  const [state, setState] = useState<JoyConState | null>(null)
+  const [isConnected, setIsConnected] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const joyConRef = useRef<JoyCon | null>(null)
+  const unsubscribeRef = useRef<(() => void) | null>(null)
+
+  const isSupported = typeof navigator !== 'undefined' && 'hid' in navigator
+
+  const connect = useCallback(async () => {
+    setError(null)
+    try {
+      const joyCon = await requestJoyCon()
+      joyConRef.current = joyCon
+      unsubscribeRef.current = joyCon.onState(setState)
+      setIsConnected(true)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    }
+  }, [])
+
+  useEffect(() => {
+    return () => {
+      unsubscribeRef.current?.()
+      void joyConRef.current?.close()
+    }
+  }, [])
+
+  return { isSupported, isConnected, state, error, connect }
+}

--- a/frontend/src/lib/joycon/constants.ts
+++ b/frontend/src/lib/joycon/constants.ts
@@ -1,0 +1,17 @@
+export const NINTENDO_VENDOR_ID = 0x057e
+
+export const JOYCON_L_PRODUCT_ID = 0x2006
+export const JOYCON_R_PRODUCT_ID = 0x2007
+
+export const OUTPUT_REPORT_ID = 0x01
+
+export const SUBCOMMAND = {
+  SET_INPUT_REPORT_MODE: 0x03,
+  ENABLE_IMU: 0x40,
+} as const
+
+// 入力レポートモード 0x30 を要求すると、以後の入力レポートは report id 0x30 で届く
+export const STANDARD_FULL_REPORT_ID = 0x30
+
+export const ACCEL_COEFFICIENT = 0.000244 // raw -> G (±8G レンジ)
+export const GYRO_COEFFICIENT = 0.07 // raw -> deg/s (±2000dps レンジ)

--- a/frontend/src/lib/joycon/joyConDevice.ts
+++ b/frontend/src/lib/joycon/joyConDevice.ts
@@ -1,0 +1,215 @@
+import {
+  ACCEL_COEFFICIENT,
+  GYRO_COEFFICIENT,
+  JOYCON_L_PRODUCT_ID,
+  JOYCON_R_PRODUCT_ID,
+  NINTENDO_VENDOR_ID,
+  OUTPUT_REPORT_ID,
+  STANDARD_FULL_REPORT_ID,
+  SUBCOMMAND,
+} from './constants'
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+export type JoyConSide = 'left' | 'right'
+
+export interface JoyConVector3 {
+  x: number
+  y: number
+  z: number
+}
+
+export interface JoyConButtons {
+  a: boolean
+  b: boolean
+  x: boolean
+  y: boolean
+  up: boolean
+  down: boolean
+  left: boolean
+  right: boolean
+  l: boolean
+  r: boolean
+  zl: boolean
+  zr: boolean
+  sl: boolean
+  sr: boolean
+  minus: boolean
+  plus: boolean
+  stick: boolean
+  home: boolean
+  capture: boolean
+}
+
+export interface JoyConState {
+  buttons: JoyConButtons
+  accel: JoyConVector3
+  gyro: JoyConVector3
+}
+
+// WebHIDの入力レポートはreport idを含まないペイロードとして届くため、
+// プロトコル資料の生バイト番号から1引いたオフセットになる。
+const BUTTON_RIGHT_OFFSET = 2
+const BUTTON_SHARED_OFFSET = 3
+const BUTTON_LEFT_OFFSET = 4
+const IMU_FIRST_SAMPLE_OFFSET = 12
+
+function emptyButtons(): JoyConButtons {
+  return {
+    a: false,
+    b: false,
+    x: false,
+    y: false,
+    up: false,
+    down: false,
+    left: false,
+    right: false,
+    l: false,
+    r: false,
+    zl: false,
+    zr: false,
+    sl: false,
+    sr: false,
+    minus: false,
+    plus: false,
+    stick: false,
+    home: false,
+    capture: false,
+  }
+}
+
+function readInt16LE(view: DataView, offset: number): number {
+  return view.getInt16(offset, true)
+}
+
+function parseButtons(view: DataView, side: JoyConSide): JoyConButtons {
+  const buttons = emptyButtons()
+  const right = view.getUint8(BUTTON_RIGHT_OFFSET)
+  const shared = view.getUint8(BUTTON_SHARED_OFFSET)
+  const left = view.getUint8(BUTTON_LEFT_OFFSET)
+
+  if (side === 'right') {
+    buttons.y = !!(right & 0x01)
+    buttons.x = !!(right & 0x02)
+    buttons.b = !!(right & 0x04)
+    buttons.a = !!(right & 0x08)
+    buttons.sr = !!(right & 0x10)
+    buttons.sl = !!(right & 0x20)
+    buttons.r = !!(right & 0x40)
+    buttons.zr = !!(right & 0x80)
+    buttons.stick = !!(shared & 0x04)
+  } else {
+    buttons.down = !!(left & 0x01)
+    buttons.up = !!(left & 0x02)
+    buttons.right = !!(left & 0x04)
+    buttons.left = !!(left & 0x08)
+    buttons.sr = !!(left & 0x10)
+    buttons.sl = !!(left & 0x20)
+    buttons.l = !!(left & 0x40)
+    buttons.zl = !!(left & 0x80)
+    buttons.stick = !!(shared & 0x08)
+  }
+
+  buttons.minus = !!(shared & 0x01)
+  buttons.plus = !!(shared & 0x02)
+  buttons.home = !!(shared & 0x10)
+  buttons.capture = !!(shared & 0x20)
+
+  return buttons
+}
+
+function parseImuSample(view: DataView, offset: number): { accel: JoyConVector3; gyro: JoyConVector3 } {
+  return {
+    accel: {
+      x: readInt16LE(view, offset) * ACCEL_COEFFICIENT,
+      y: readInt16LE(view, offset + 2) * ACCEL_COEFFICIENT,
+      z: readInt16LE(view, offset + 4) * ACCEL_COEFFICIENT,
+    },
+    gyro: {
+      x: readInt16LE(view, offset + 6) * GYRO_COEFFICIENT,
+      y: readInt16LE(view, offset + 8) * GYRO_COEFFICIENT,
+      z: readInt16LE(view, offset + 10) * GYRO_COEFFICIENT,
+    },
+  }
+}
+
+export class JoyCon extends EventTarget {
+  readonly device: HIDDevice
+  readonly side: JoyConSide
+  private packetNumber = 0
+
+  constructor(device: HIDDevice) {
+    super()
+    this.device = device
+    this.side = device.productId === JOYCON_L_PRODUCT_ID ? 'left' : 'right'
+  }
+
+  static isJoyCon(device: HIDDevice): boolean {
+    return (
+      device.vendorId === NINTENDO_VENDOR_ID &&
+      (device.productId === JOYCON_L_PRODUCT_ID || device.productId === JOYCON_R_PRODUCT_ID)
+    )
+  }
+
+  async open(): Promise<void> {
+    if (!this.device.opened) {
+      await this.device.open()
+    }
+    this.device.addEventListener('inputreport', this.handleInputReport)
+    await this.sendSubcommand(SUBCOMMAND.SET_INPUT_REPORT_MODE, [STANDARD_FULL_REPORT_ID])
+    // Bluetooth経由だと連続送信した2つ目のサブコマンドが無視されることがあるため間隔を空ける
+    await sleep(150)
+    await this.sendSubcommand(SUBCOMMAND.ENABLE_IMU, [0x01])
+  }
+
+  async close(): Promise<void> {
+    this.device.removeEventListener('inputreport', this.handleInputReport)
+    if (this.device.opened) {
+      await this.device.close()
+    }
+  }
+
+  onState(listener: (state: JoyConState) => void): () => void {
+    const handler = (event: Event) => listener((event as CustomEvent<JoyConState>).detail)
+    this.addEventListener('state', handler)
+    return () => this.removeEventListener('state', handler)
+  }
+
+  private async sendSubcommand(subcommand: number, args: number[]): Promise<void> {
+    const neutralRumble = [0x00, 0x01, 0x40, 0x40, 0x00, 0x01, 0x40, 0x40]
+    const data = new Uint8Array([this.packetNumber & 0x0f, ...neutralRumble, subcommand, ...args])
+    this.packetNumber += 1
+    await this.device.sendReport(OUTPUT_REPORT_ID, data)
+  }
+
+  private handleInputReport = (event: HIDInputReportEvent): void => {
+    if (event.reportId !== STANDARD_FULL_REPORT_ID) return
+
+    const state: JoyConState = {
+      buttons: parseButtons(event.data, this.side),
+      ...parseImuSample(event.data, IMU_FIRST_SAMPLE_OFFSET),
+    }
+
+    this.dispatchEvent(new CustomEvent('state', { detail: state }))
+  }
+}
+
+export async function requestJoyCon(): Promise<JoyCon> {
+  const devices = await navigator.hid.requestDevice({
+    filters: [
+      { vendorId: NINTENDO_VENDOR_ID, productId: JOYCON_L_PRODUCT_ID },
+      { vendorId: NINTENDO_VENDOR_ID, productId: JOYCON_R_PRODUCT_ID },
+    ],
+  })
+
+  const device = devices.find(JoyCon.isJoyCon)
+  if (!device) {
+    throw new Error('Joy-Conが選択されませんでした')
+  }
+
+  const joyCon = new JoyCon(device)
+  await joyCon.open()
+  return joyCon
+}

--- a/frontend/src/pages/ConnectPage.tsx
+++ b/frontend/src/pages/ConnectPage.tsx
@@ -1,8 +1,8 @@
 import { Link } from 'react-router-dom'
-import { useJoyCon } from '../hooks/useJoyCon'
+import { useJoyConContext } from '../contexts/JoyConContext'
 
 function ConnectPage() {
-  const { isSupported, isConnected, state, error, connect } = useJoyCon()
+  const { isSupported, isConnected, state, error, connect } = useJoyConContext()
 
   return (
     <section>

--- a/frontend/src/pages/ConnectPage.tsx
+++ b/frontend/src/pages/ConnectPage.tsx
@@ -1,10 +1,43 @@
 import { Link } from 'react-router-dom'
+import { useJoyCon } from '../hooks/useJoyCon'
 
 function ConnectPage() {
+  const { isSupported, isConnected, state, error, connect } = useJoyCon()
+
   return (
     <section>
       <h1>Joy-Con接続</h1>
-      <Link to="/game">ゲームへ</Link>
+
+      {!isSupported && <p>このブラウザはWebHIDに対応していません。Chrome / Edgeで開いてください。</p>}
+
+      {isSupported && !isConnected && (
+        <button type="button" onClick={connect}>
+          Joy-Conを接続する
+        </button>
+      )}
+
+      {error && <p role="alert">{error}</p>}
+
+      {isConnected && (
+        <div>
+          <p>接続済み</p>
+          {state && (
+            <dl>
+              <dt>加速度 (G)</dt>
+              <dd>
+                x: {state.accel.x.toFixed(2)} / y: {state.accel.y.toFixed(2)} / z:{' '}
+                {state.accel.z.toFixed(2)}
+              </dd>
+              <dt>ジャイロ (deg/s)</dt>
+              <dd>
+                x: {state.gyro.x.toFixed(1)} / y: {state.gyro.y.toFixed(1)} / z:{' '}
+                {state.gyro.z.toFixed(1)}
+              </dd>
+            </dl>
+          )}
+          <Link to="/game">ゲームへ</Link>
+        </div>
+      )}
     </section>
   )
 }

--- a/frontend/src/pages/GamePage.tsx
+++ b/frontend/src/pages/GamePage.tsx
@@ -1,9 +1,18 @@
 import { Link } from 'react-router-dom'
+import LightsaberScene from '../components/three/LightsaberScene'
+import { useJoyConContext } from '../contexts/JoyConContext'
 
 function GamePage() {
+  const { isConnected, state } = useJoyConContext()
+
   return (
     <section>
       <h1>ゲーム</h1>
+
+      {!isConnected && <p>Joy-Conが未接続です。先に接続画面で接続してください。</p>}
+
+      <LightsaberScene gyro={state?.gyro ?? null} />
+
       <Link to="/result">リザルトへ</Link>
     </section>
   )

--- a/frontend/src/types/webhid.d.ts
+++ b/frontend/src/types/webhid.d.ts
@@ -1,0 +1,43 @@
+interface HIDDeviceFilter {
+  vendorId?: number
+  productId?: number
+}
+
+interface HIDDeviceRequestOptions {
+  filters: HIDDeviceFilter[]
+}
+
+interface HIDInputReportEvent extends Event {
+  readonly device: HIDDevice
+  readonly reportId: number
+  readonly data: DataView
+}
+
+interface HIDDevice extends EventTarget {
+  readonly opened: boolean
+  readonly vendorId: number
+  readonly productId: number
+  readonly productName: string
+  open(): Promise<void>
+  close(): Promise<void>
+  sendReport(reportId: number, data: BufferSource): Promise<void>
+  addEventListener(
+    type: 'inputreport',
+    listener: (event: HIDInputReportEvent) => void,
+    options?: boolean | AddEventListenerOptions,
+  ): void
+  removeEventListener(
+    type: 'inputreport',
+    listener: (event: HIDInputReportEvent) => void,
+    options?: boolean | EventListenerOptions,
+  ): void
+}
+
+interface HID extends EventTarget {
+  requestDevice(options: HIDDeviceRequestOptions): Promise<HIDDevice[]>
+  getDevices(): Promise<HIDDevice[]>
+}
+
+interface Navigator {
+  readonly hid: HID
+}


### PR DESCRIPTION
## 概要
Joy-Con(WebHID) → 加速度・ジャイロ取得 → 3Dライトセーバー
実機のJoy-Conで振ると画面上のライトセーバーが連動して動く

## やったこと
- WebHIDでJoy-Conに接続し、加速度・ジャイロを取得する処理を追加（`lib/joycon/`, `hooks/useJoyCon.ts`）
- 接続画面(`/connect`)でJoy-Conを接続し、センサー値をリアルタイム表示
- 接続状態を`JoyConContext`でアプリ全体に共有し、`/connect`→`/game`と画面をまたいでも接続を維持
- React Three Fiberでライトセーバーの3Dモデルを表示し、ジャイロの角速度を積分して姿勢に反映

## 動作確認
- Chrome/EdgeでJoy-Con(L/R)を接続し、加速度・ジャイロの値が振ると変化することを確認
- `/game`画面でJoy-Conを振ると3Dのライトセーバーが連動して動くことを確認
- `npm run build`が通ることを確認

## 既知の制限
- ジャイロの積分のみで姿勢を出しているため、振り続けると徐々にズレる（ドリフト）
- ページをリロードするとJoy-Con接続は切れ、再接続が必要
- WebHID非対応ブラウザ(Firefox/Safari)向けの代替手段は未実装
