### PR TITLE
infra: バックエンドAPIをCloudflare Containersへデプロイ

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -1,10 +1,6 @@
 name: Deploy Backend
 
 on:
-  pull_request:
-    paths:
-      - 'backend/**'
-      - '.github/workflows/deploy-backend.yml'
   push:
     branches:
       - main
@@ -12,70 +8,19 @@ on:
       - 'backend/**'
       - '.github/workflows/deploy-backend.yml'
 
-# 同一ブランチへの連続プッシュでイメージのビルド・アップロードが競合しないよう直列化する。
+# 同一ブランチへの連続プッシュでイメージのビルド・ロールアウトが競合しないよう直列化する。
+# 本番デプロイの中断は避けたいのでキャンセルはしない。
 concurrency:
   group: deploy-backend-${{ github.ref }}
-  # 本番デプロイの中断は避けたいので、PRのプレビューのみキャンセル対象にする。
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: false
 
+# フロントエンドと違い、PRでのプレビューデプロイは用意していない。
+# Containers Worker は Durable Object を持つため Preview URL が発行されず、
+# `wrangler versions upload` はコンテナイメージの publish もロールアウトも行わないため。
+# https://developers.cloudflare.com/containers/deploy/
 jobs:
-  preview:
-    name: Preview deploy
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      # プレビューURLをPRにコメントするために必要。
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          cache: npm
-          cache-dependency-path: backend/package-lock.json
-      - run: npm ci
-        working-directory: backend
-
-      # versions upload は新しいバージョンをアップロードするだけで、
-      # 本番トラフィックの向き先は変更しない。
-      # コンテナイメージのビルドには Docker が必要だが、ubuntu-latest には同梱されている。
-      - name: Upload preview version
-        id: upload
-        uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3.15.0
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          workingDirectory: backend
-          # backend/package.json の devDependencies と揃える。
-          wranglerVersion: '4.126.0'
-          command: versions upload
-
-      # 同じPRに何度もコメントが積まれないよう、既存コメントがあれば編集する。
-      - name: Comment preview URL
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          PREVIEW_URL: ${{ steps.upload.outputs.deployment-url }}
-          COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          marker='<!-- backend-preview -->'
-          body=$(printf '%s\n### 🛠 バックエンド プレビュー\n\n| | |\n| --- | --- |\n| **Preview URL** | %s |\n| **Commit** | %s |\n' \
-            "$marker" "$PREVIEW_URL" "$COMMIT_SHA")
-
-          comment_id=$(gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
-            | jq -rs --arg marker "$marker" \
-              'add | map(select(.body | startswith($marker))) | .[0].id // empty')
-
-          if [ -n "$comment_id" ]; then
-            gh api --method PATCH "repos/$GITHUB_REPOSITORY/issues/comments/$comment_id" -f body="$body"
-          else
-            gh api --method POST "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" -f body="$body"
-          fi
-
   deploy:
     name: Production deploy
-    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -89,6 +34,7 @@ jobs:
       - run: npm ci
         working-directory: backend
 
+      # コンテナイメージのビルドには Docker が必要だが、ubuntu-latest には同梱されている。
       - name: Deploy to production
         id: deploy
         uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3.15.0

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -1,0 +1,104 @@
+name: Deploy Backend
+
+on:
+  pull_request:
+    paths:
+      - 'backend/**'
+      - '.github/workflows/deploy-backend.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'backend/**'
+      - '.github/workflows/deploy-backend.yml'
+
+# 同一ブランチへの連続プッシュでイメージのビルド・アップロードが競合しないよう直列化する。
+concurrency:
+  group: deploy-backend-${{ github.ref }}
+  # 本番デプロイの中断は避けたいので、PRのプレビューのみキャンセル対象にする。
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  preview:
+    name: Preview deploy
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # プレビューURLをPRにコメントするために必要。
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+      - run: npm ci
+        working-directory: backend
+
+      # versions upload は新しいバージョンをアップロードするだけで、
+      # 本番トラフィックの向き先は変更しない。
+      # コンテナイメージのビルドには Docker が必要だが、ubuntu-latest には同梱されている。
+      - name: Upload preview version
+        id: upload
+        uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3.15.0
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: backend
+          # backend/package.json の devDependencies と揃える。
+          wranglerVersion: '4.126.0'
+          command: versions upload
+
+      # 同じPRに何度もコメントが積まれないよう、既存コメントがあれば編集する。
+      - name: Comment preview URL
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PREVIEW_URL: ${{ steps.upload.outputs.deployment-url }}
+          COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          marker='<!-- backend-preview -->'
+          body=$(printf '%s\n### 🛠 バックエンド プレビュー\n\n| | |\n| --- | --- |\n| **Preview URL** | %s |\n| **Commit** | %s |\n' \
+            "$marker" "$PREVIEW_URL" "$COMMIT_SHA")
+
+          comment_id=$(gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
+            | jq -rs --arg marker "$marker" \
+              'add | map(select(.body | startswith($marker))) | .[0].id // empty')
+
+          if [ -n "$comment_id" ]; then
+            gh api --method PATCH "repos/$GITHUB_REPOSITORY/issues/comments/$comment_id" -f body="$body"
+          else
+            gh api --method POST "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" -f body="$body"
+          fi
+
+  deploy:
+    name: Production deploy
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+      - run: npm ci
+        working-directory: backend
+
+      - name: Deploy to production
+        id: deploy
+        uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3.15.0
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: backend
+          # backend/package.json の devDependencies と揃える。
+          wranglerVersion: '4.126.0'
+          command: deploy
+
+      - name: Show deployment URL
+        run: echo "本番URL ${{ steps.deploy.outputs.deployment-url }}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -41,3 +41,21 @@ jobs:
       - run: test -z "$(gofmt -l .)"
       - run: go vet ./...
       - run: go test ./...
+
+  backend-worker:
+    name: Backend worker quality
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+      - run: npm ci
+      # worker-configuration.d.ts はコミットしないため、型検査の前に生成する。
+      - run: npx wrangler types
+      - run: npm run typecheck

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -67,11 +67,11 @@ tasks:
     cmds:
       - npm run deploy
 
-  deploy:backend:preview:
-    desc: バックエンドのプレビュー版をアップロード（本番トラフィックは変更しない）
+  dev:backend:container:
+    desc: Worker＋コンテナをローカルで起動して本番構成を再現（Docker起動が必要）
     dir: backend
     cmds:
-      - npm run deploy:preview
+      - npm run dev
 
   ci:
     desc: GitHub Actions と同じ品質チェックを実行

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -61,11 +61,24 @@ tasks:
     cmds:
       - npm run deploy:preview
 
+  deploy:backend:
+    desc: バックエンドをCloudflare Containersの本番へデプロイ（Docker起動が必要）
+    dir: backend
+    cmds:
+      - npm run deploy
+
+  deploy:backend:preview:
+    desc: バックエンドのプレビュー版をアップロード（本番トラフィックは変更しない）
+    dir: backend
+    cmds:
+      - npm run deploy:preview
+
   ci:
     desc: GitHub Actions と同じ品質チェックを実行
     deps:
       - ci:frontend
       - ci:backend
+      - ci:backend:worker
 
   ci:frontend:
     internal: true
@@ -84,3 +97,12 @@ tasks:
       - test -z "$(gofmt -l .)"
       - go vet ./...
       - go test ./...
+
+  ci:backend:worker:
+    internal: true
+    dir: backend
+    cmds:
+      - npm ci
+      # worker-configuration.d.ts はコミットしないため、型検査の前に生成する。
+      - npx wrangler types
+      - npm run typecheck

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,18 @@
+# Go のビルドキャッシュ（backend/.gitignore と揃える）
+.gocache/
+.gopath/
+
+# ローカル専用の設定。シークレットをイメージに焼かないため必ず除外する。
+.env
+
+# Worker シム側の成果物。コンテナのビルドには不要。
+node_modules/
+.wrangler/
+worker/
+package.json
+package-lock.json
+tsconfig.json
+wrangler.jsonc
+
+# ドキュメント
+README.md

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,3 +1,9 @@
 .gocache/
 .gopath/
 .env
+
+# Worker シム（Cloudflare Containers）関連
+node_modules/
+.wrangler/
+# wrangler types が生成するため、コミットしない
+worker-configuration.d.ts

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -7,3 +7,6 @@ node_modules/
 .wrangler/
 # wrangler types が生成するため、コミットしない
 worker-configuration.d.ts
+
+# wrangler dev 用のローカルシークレット
+.dev.vars

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,31 @@
+# Cloudflare Containers は linux/amd64 でのみ動作するため、明示的に固定する。
+# （Apple Silicon から wrangler deploy する場合もこの指定でクロスビルドされる。）
+FROM --platform=linux/amd64 golang:1.27-alpine AS build
+
+WORKDIR /src
+
+# 依存の取得だけを先に行い、ソース変更時のレイヤーキャッシュを効かせる。
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+# CGO_ENABLED=0 で静的リンクし、scratch 相当の最小イメージで動くようにする。
+# -trimpath と -ldflags="-s -w" はバイナリサイズを削るため。
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+    go build -trimpath -ldflags="-s -w" -o /out/server ./cmd/server
+
+FROM --platform=linux/amd64 gcr.io/distroless/static-debian12:nonroot
+
+# マネージドPostgres への TLS 接続でルート証明書が必要になるが、
+# distroless/static には ca-certificates が同梱されているためコピー不要。
+
+WORKDIR /app
+COPY --from=build /out/server /app/server
+
+# Container クラスの defaultPort と、backend の PORT のデフォルトに揃える。
+EXPOSE 8080
+ENV PORT=8080
+
+USER nonroot:nonroot
+ENTRYPOINT ["/app/server"]

--- a/backend/README.md
+++ b/backend/README.md
@@ -121,6 +121,18 @@ $env:DATABASE_URL = "postgres://wip:wip_password@localhost:5432/wip?sslmode=disa
 go run ./cmd/server
 ```
 
+## デプロイ
+
+Cloudflare Containers へデプロイする。手順・構成・既知の課題は
+[docs/backend-deploy.md](../docs/backend-deploy.md) を参照。
+
+```bash
+task deploy:backend          # 本番へデプロイ
+task deploy:backend:preview  # プレビュー版をアップロード
+```
+
+`main` への push で自動デプロイされるため、通常は手動実行は不要。
+
 ## 目的
 
 - ゲームのスコアを保存する

--- a/backend/README.md
+++ b/backend/README.md
@@ -127,8 +127,8 @@ Cloudflare Containers へデプロイする。手順・構成・既知の課題�
 [docs/backend-deploy.md](../docs/backend-deploy.md) を参照。
 
 ```bash
-task deploy:backend          # 本番へデプロイ
-task deploy:backend:preview  # プレビュー版をアップロード
+task deploy:backend            # 本番へデプロイ
+task dev:backend:container     # Worker＋コンテナをローカルで起動
 ```
 
 `main` への push で自動デプロイされるため、通常は手動実行は不要。

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,0 +1,1611 @@
+{
+  "name": "wip-backend-worker",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "wip-backend-worker",
+      "version": "0.0.0",
+      "dependencies": {
+        "@cloudflare/containers": "^0.3.7"
+      },
+      "devDependencies": {
+        "typescript": "~6.0.2",
+        "wrangler": "^4.126.0"
+      }
+    },
+    "node_modules/@cloudflare/containers": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@cloudflare/containers/-/containers-0.3.7.tgz",
+      "integrity": "sha512-DM9dm3FnIBSyiSJ1FLavKwl/lk3oAmTaynCzZQ9pZR0ncRPquSxkxd8Nu2MFILxmDDsPkxKsSNEh9mHHMty4Fw==",
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260825.1.tgz",
+      "integrity": "sha512-oHu38dwaUuzAilyTb0QkQ1YxU/kzqzIQybCvQKAhiK1CGtQS9h0MmjIZYogv3g8cFGGY2k+Wxs0wV9hHK8z78g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260825.1.tgz",
+      "integrity": "sha512-ak5zh8YGEjxQQ78bVo7gzU+tcg2fSFxMIjOPZtWk56a/rIYLbGu6ECcliqnYfMUlragg68H0JuVpfdr3BR5Alw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260825.1.tgz",
+      "integrity": "sha512-bNQvzz6NemWAwixDRz1fQa5T+E5lS4xpB7A/H/72ULxrjVpHmq8CGFPSbdmRp3dvgBjZTgp7wHdGLISLSVd9Gg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260825.1.tgz",
+      "integrity": "sha512-a5E61YsnNCHHQMnmYsbVXInzeYqFqAMwm/wo16dWW4klXDr6T1bm7u1h5G7ZkxVM7+rtc69oe0yVHjDEqzpYVg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260825.1.tgz",
+      "integrity": "sha512-EokzVY2suzRSzeURi2HpHnySR5mo6aF5V1klFIqFOZp2YJyXXTI8AvQgYzhlmGTZY3LNL41jjkUQunOM2OErgQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.2.tgz",
+      "integrity": "sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.2.tgz",
+      "integrity": "sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.2.tgz",
+      "integrity": "sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.1.tgz",
+      "integrity": "sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.1.tgz",
+      "integrity": "sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.1.tgz",
+      "integrity": "sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.1.tgz",
+      "integrity": "sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.1.tgz",
+      "integrity": "sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.1.tgz",
+      "integrity": "sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.1.tgz",
+      "integrity": "sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.1.tgz",
+      "integrity": "sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.1.tgz",
+      "integrity": "sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.1.tgz",
+      "integrity": "sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.2.tgz",
+      "integrity": "sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.2.tgz",
+      "integrity": "sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.2.tgz",
+      "integrity": "sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.2.tgz",
+      "integrity": "sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.2.tgz",
+      "integrity": "sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.2.tgz",
+      "integrity": "sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.2.tgz",
+      "integrity": "sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.2.tgz",
+      "integrity": "sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.2.tgz",
+      "integrity": "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==",
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.2.tgz",
+      "integrity": "sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.2.tgz",
+      "integrity": "sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.2.tgz",
+      "integrity": "sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.2.tgz",
+      "integrity": "sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.24",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.24.tgz",
+      "integrity": "sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "5.20260825.0-alpha",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260825.0-alpha.tgz",
+      "integrity": "sha512-ZwlF6LuX43ilx9EwMRDKHenoGXiNdcKSyGx5aPaJhuozujVZasb2lRR7t3ojJZSnVzwDPsBBYCu8lLnc+/KIgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "0.35.2",
+        "undici": "7.29.0",
+        "workerd": "1.20260825.1",
+        "ws": "8.21.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.2.tgz",
+      "integrity": "sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.1.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.8.4"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.35.2",
+        "@img/sharp-darwin-x64": "0.35.2",
+        "@img/sharp-freebsd-wasm32": "0.35.2",
+        "@img/sharp-libvips-darwin-arm64": "1.3.1",
+        "@img/sharp-libvips-darwin-x64": "1.3.1",
+        "@img/sharp-libvips-linux-arm": "1.3.1",
+        "@img/sharp-libvips-linux-arm64": "1.3.1",
+        "@img/sharp-libvips-linux-ppc64": "1.3.1",
+        "@img/sharp-libvips-linux-riscv64": "1.3.1",
+        "@img/sharp-libvips-linux-s390x": "1.3.1",
+        "@img/sharp-libvips-linux-x64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1",
+        "@img/sharp-linux-arm": "0.35.2",
+        "@img/sharp-linux-arm64": "0.35.2",
+        "@img/sharp-linux-ppc64": "0.35.2",
+        "@img/sharp-linux-riscv64": "0.35.2",
+        "@img/sharp-linux-s390x": "0.35.2",
+        "@img/sharp-linux-x64": "0.35.2",
+        "@img/sharp-linuxmusl-arm64": "0.35.2",
+        "@img/sharp-linuxmusl-x64": "0.35.2",
+        "@img/sharp-webcontainers-wasm32": "0.35.2",
+        "@img/sharp-win32-arm64": "0.35.2",
+        "@img/sharp-win32-ia32": "0.35.2",
+        "@img/sharp-win32-x64": "0.35.2"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260825.1.tgz",
+      "integrity": "sha512-ccS6TEaaRxgONKawiYGnFYUVGfr2pmN1b7mrNtw0ADVhFaYsEIVoCHnQ4UjhM9EJDzuaNgAWFY82nzVrjWpuOA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260825.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260825.1",
+        "@cloudflare/workerd-linux-64": "1.20260825.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260825.1",
+        "@cloudflare/workerd-windows-64": "1.20260825.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.126.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.126.0.tgz",
+      "integrity": "sha512-glDq/nxaeQwue0XMIeupfwlu2jVxnFs+wjDFT71DQuURN5LsVdCwu0Af/1ep10U5xr1rKPGhHDEDkKG9nxE/dg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.28.1",
+        "miniflare": "5.20260825.0-alpha",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260825.1"
+      },
+      "bin": {
+        "cf-wrangler": "bin/cf-wrangler.js",
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^5.20260825.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    }
+  }
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "wip-backend-worker",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "deploy": "wrangler deploy",
+    "deploy:preview": "wrangler versions upload",
+    "typecheck": "tsc --noEmit",
+    "cf-typegen": "wrangler types"
+  },
+  "dependencies": {
+    "@cloudflare/containers": "^0.3.7"
+  },
+  "devDependencies": {
+    "typescript": "~6.0.2",
+    "wrangler": "^4.126.0"
+  }
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "deploy": "wrangler deploy",
-    "deploy:preview": "wrangler versions upload",
+    "dev": "wrangler dev",
     "typecheck": "tsc --noEmit",
     "cf-typegen": "wrangler types"
   },

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "lib": ["es2022"],
+    "module": "es2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["worker/**/*.ts", "worker/**/*.d.ts", "worker-configuration.d.ts"]
+}

--- a/backend/worker/env.d.ts
+++ b/backend/worker/env.d.ts
@@ -1,0 +1,12 @@
+/**
+ * `wrangler secret put DATABASE_URL` で登録する Worker Secret の型宣言。
+ *
+ * シークレットは wrangler.jsonc に書かないため `wrangler types` が生成する
+ * worker-configuration.d.ts には現れない。ここで Cloudflare.Env を拡張して
+ * `env.DATABASE_URL` を型安全に参照できるようにする。
+ */
+declare namespace Cloudflare {
+  interface Env {
+    DATABASE_URL: string;
+  }
+}

--- a/backend/worker/index.ts
+++ b/backend/worker/index.ts
@@ -1,0 +1,52 @@
+import { Container, getRandom } from '@cloudflare/containers';
+import { env } from 'cloudflare:workers';
+
+/**
+ * リクエストを分散させるコンテナインスタンス数。
+ * wrangler.jsonc の containers[].max_instances 以下にすること。
+ */
+const INSTANCE_COUNT = 2;
+
+export class BackendContainer extends Container {
+  // backend/Dockerfile の EXPOSE と、Go 側の PORT デフォルトに揃える。
+  defaultPort = 8080;
+
+  /**
+   * 最終リクエストからこの時間アイドルだとコンテナを停止する。
+   * 停止中は課金されないが、次のリクエストはコールドスタート（Go の起動＋
+   * Postgres への TCP/TLS ハンドシェイク）を待つことになる。
+   * MVP ではコスト優先で短めにしている。
+   */
+  sleepAfter = '5m';
+
+  /**
+   * コンテナへ渡す環境変数。
+   * DATABASE_URL は `wrangler secret put DATABASE_URL` で登録した Worker Secret を
+   * 中継している。値そのものはこのリポジトリには含めない。
+   */
+  envVars = {
+    DATABASE_URL: env.DATABASE_URL,
+    CORS_ALLOW_ORIGINS: env.CORS_ALLOW_ORIGINS,
+  };
+
+  override onStart() {
+    console.log('backend container started');
+  }
+
+  override onStop(stopParams: { exitCode: number; reason: string }) {
+    console.log('backend container stopped', stopParams);
+  }
+
+  override onError(error: unknown) {
+    console.error('backend container error:', error);
+  }
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    // APIサーバーはステートレスなので、パスで固定インスタンスに寄せず
+    // ランダムに分散させる（getByName だとパスごとにインスタンスが割れる）。
+    const container = await getRandom(env.BACKEND, INSTANCE_COUNT);
+    return container.fetch(request);
+  },
+} satisfies ExportedHandler<Env>;

--- a/backend/wrangler.jsonc
+++ b/backend/wrangler.jsonc
@@ -1,0 +1,48 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "wip-backend",
+  "main": "worker/index.ts",
+  "compatibility_date": "2026-08-27",
+  "compatibility_flags": ["nodejs_compat"],
+
+  // Preview URL は workers.dev のサブドメインで配信されるため、両方を明示的に有効化する。
+  "workers_dev": true,
+  "preview_urls": true,
+
+  "containers": [
+    {
+      "class_name": "BackendContainer",
+      "image": "./Dockerfile",
+      // lite（256MiB）は Gin + GORM + pgx にはやや窮屈なため basic を使う。
+      "instance_type": "basic",
+      // worker/index.ts の INSTANCE_COUNT 以上にすること。
+      "max_instances": 2,
+    },
+  ],
+
+  "durable_objects": {
+    "bindings": [
+      {
+        "name": "BACKEND",
+        "class_name": "BackendContainer",
+      },
+    ],
+  },
+
+  "migrations": [
+    {
+      "tag": "v1",
+      "new_sqlite_classes": ["BackendContainer"],
+    },
+  ],
+
+  // コンテナへ中継する非機密の設定値。
+  // DATABASE_URL は機密なので vars ではなく `wrangler secret put` で登録する。
+  "vars": {
+    "CORS_ALLOW_ORIGINS": "https://wip-frontend.uomi.dev,https://wip-frontend.uozumi05.workers.dev",
+  },
+
+  "observability": {
+    "enabled": true,
+  },
+}

--- a/docs/backend-deploy.md
+++ b/docs/backend-deploy.md
@@ -39,11 +39,21 @@ Hyperdrive が効くのは「Worker 内で JS のドライバから直接クエ�
 
 | 種類 | トリガー | コマンド | 公開先 |
 | --- | --- | --- | --- |
-| プレビュー | `backend/**` を変更した Pull Request | `wrangler versions upload` | [Preview URL](https://developers.cloudflare.com/workers/versions-and-deployments/preview-urls/)（`https://<バージョン>-wip-backend.uozumi05.workers.dev`） |
 | 本番 | `main` への push | `wrangler deploy` | https://wip-backend.uozumi05.workers.dev |
 
-`versions upload` は新しいバージョンをアップロードするだけで、本番トラフィックの向き先は変更しない。
-プレビューURLは PR に自動でコメントされる。
+### プレビューデプロイが無い理由
+
+フロントエンドと違い、PR でのプレビューデプロイは用意していない。
+[Cloudflare のドキュメント](https://developers.cloudflare.com/containers/deploy/)に次のとおり明記されている。
+
+- **Preview URL は Durable Object を持つ Worker には発行されない**。Containers Worker は
+  コンテナを Durable Object で制御するため、これに該当する。
+- `wrangler versions upload` は Worker のバージョンを上げるだけで、
+  **コンテナイメージの publish もインスタンスのロールアウトも行わない**。
+
+つまり `versions upload` を回しても、新しいコンテナを動かして確認する手段が無い。
+PR の段階でコンテナの動作を確認したい場合は、後述の
+[ローカルで本番構成を再現する](#ローカルで本番構成を再現する)を使う。
 
 ## 事前に必要な設定
 
@@ -57,7 +67,7 @@ Containers は **Workers Paid プラン（月$5〜）** が必要。Free プラ�
 
 | 名前 | 内容 |
 | --- | --- |
-| `CLOUDFLARE_API_TOKEN` | Cloudflare の API トークン。**Workers Scripts: Edit** に加え、コンテナイメージを push するため **Containers: Edit** が必要 |
+| `CLOUDFLARE_API_TOKEN` | Cloudflare の API トークン。権限は **Workers Scripts: Edit**。コンテナイメージの push もこの権限で行われる（Containers 専用の権限区分は無い） |
 | `CLOUDFLARE_ACCOUNT_ID` | Cloudflare のアカウントID |
 
 ### Cloudflare 側のシークレット
@@ -75,7 +85,9 @@ npx wrangler secret put DATABASE_URL
 
 > [!IMPORTANT]
 > 本番用のマネージドPostgres自体はまだ用意していない（Issue #28）。
-> `DATABASE_URL` を登録するまで、デプロイしたAPIの `/health` は 503 を返す。
+> `DATABASE_URL` を登録するまでコンテナは起動に失敗し続ける（後述の
+> [設定不備がクラッシュループになる](#設定不備がクラッシュループになる)）。
+> `/health` が 503 を返すのではなく、そもそもAPIが応答しない点に注意する。
 
 非機密の `CORS_ALLOW_ORIGINS` は `backend/wrangler.jsonc` の `vars` に直接書いている。
 フロントエンドのオリジンを変える場合はここを編集する。
@@ -95,8 +107,7 @@ VITE_API_BASE_URL=https://wip-backend.uozumi05.workers.dev
 ## ローカルからのデプロイ
 
 ```bash
-task deploy:backend          # 本番へデプロイ
-task deploy:backend:preview  # プレビュー版をアップロード
+task deploy:backend  # 本番へデプロイ
 ```
 
 初回は `npx wrangler login` で Cloudflare にログインしておく。
@@ -118,9 +129,32 @@ task deploy:backend:preview  # プレビュー版をアップロード
 `sleepAfter` の時間だけリクエストが無いとコンテナは停止する。停止中は課金されないが、
 次のリクエストはコールドスタート（Goの起動 + Postgresへの TCP/TLS ハンドシェイク）を待つ。
 
-## ローカルでコンテナを検証する
+## ローカルで本番構成を再現する
 
-`wrangler deploy` を通さずに、イメージ単体の動作を確認できる。
+`wrangler dev` を使うと、Worker とコンテナを繋いだ**本番と同じ構成**をローカルで起動できる。
+コンテナイメージのビルドから DO バインディング、`getRandom` による分散まで一通り動く。
+
+```bash
+task db:up                  # ローカルPostgresを起動
+task dev:backend:container  # Worker＋コンテナを起動（初回はイメージのビルドで数分かかる）
+
+curl http://localhost:8787/health
+```
+
+`DATABASE_URL` は `backend/.dev.vars` から読まれる。本番の Worker Secret に相当するもので、
+コミットされない（`.gitignore` 済み）。手元に無い場合は次の内容で作る。
+
+```bash
+# backend/.dev.vars
+DATABASE_URL="postgres://wip:wip_password@host.docker.internal:5432/wip?sslmode=disable"
+```
+
+コンテナからホストの Postgres を見るため、ホスト名は `localhost` ではなく
+`host.docker.internal` になる点に注意する。
+
+## コンテナイメージ単体を検証する
+
+Worker を通さずイメージだけを確認したい場合。
 
 ```bash
 task db:up   # ローカルPostgresを起動
@@ -156,5 +190,8 @@ MVP はテーブルが `scores` ひとつだけで `AutoMigrate` は冪等に働
 
 `main.go` は `DATABASE_URL` が未設定だと `log.Fatal` で終了する。
 このときHTTPエラーは返らず、コンテナが起動しては落ちるだけになる。
+HTTPレベルでは Worker がコンテナへ接続できないエラーとして現れるため、
+`/health` の 503（DBには到達できるが疎通に失敗した状態）とは別物であることに注意する。
+
 原因は Cloudflare ダッシュボードの Workers > wip-backend > Logs、
 または `npx wrangler tail` で確認する。

--- a/docs/backend-deploy.md
+++ b/docs/backend-deploy.md
@@ -39,7 +39,7 @@ Hyperdrive が効くのは「Worker 内で JS のドライバから直接クエ�
 
 | 種類 | トリガー | コマンド | 公開先 |
 | --- | --- | --- | --- |
-| 本番 | `main` への push | `wrangler deploy` | https://wip-backend.uozumi05.workers.dev |
+| 本番 | `main` への push | `wrangler deploy` | `https://wip-backend.uozumi05.workers.dev`（想定。初回デプロイ後に確定する） |
 
 ### プレビューデプロイが無い理由
 
@@ -141,16 +141,21 @@ task dev:backend:container  # Worker＋コンテナを起動（初回はイメ�
 curl http://localhost:8787/health
 ```
 
-`DATABASE_URL` は `backend/.dev.vars` から読まれる。本番の Worker Secret に相当するもので、
-コミットされない（`.gitignore` 済み）。手元に無い場合は次の内容で作る。
+ローカル用の設定は `backend/.dev.vars` から読まれる。コミットされない（`.gitignore` 済み）ので、
+手元に無い場合は次の内容で作る。
 
 ```bash
 # backend/.dev.vars
 DATABASE_URL="postgres://wip:wip_password@host.docker.internal:5432/wip?sslmode=disable"
+CORS_ALLOW_ORIGINS="http://localhost:3000,http://localhost:5173"
 ```
 
-コンテナからホストの Postgres を見るため、ホスト名は `localhost` ではなく
-`host.docker.internal` になる点に注意する。
+2点とも `wrangler.jsonc` の設定を上書きするために必要になる。
+
+- `DATABASE_URL` は本番の Worker Secret に相当する。コンテナからホストの Postgres を見るため、
+  ホスト名は `localhost` ではなく `host.docker.internal` を使う。
+- `CORS_ALLOW_ORIGINS` は `wrangler.jsonc` の `vars` が**本番オリジンのみ**を指しているため、
+  上書きしないとローカルの Vite（`localhost:5173`）からのリクエストが 403 になる。
 
 ## コンテナイメージ単体を検証する
 
@@ -172,6 +177,21 @@ curl -i http://localhost:18099/health
 ホスト側のポートは空いていれば何でもよい。コンテナ側は `8080` 固定
 （`Dockerfile` の `EXPOSE` と `worker/index.ts` の `defaultPort` を揃えてある）。
 
+## 残作業
+
+デプロイの仕組みは用意したが、**まだ一度もデプロイしていない**。
+本番を動かすには以下を順に進める。各手順が次の手順の前提になっている。
+
+1. **マネージドPostgresを用意する**（Issue #28）。接続文字列を入手する。
+2. **`DATABASE_URL` を登録する**。`cd backend && npx wrangler secret put DATABASE_URL`。
+   これを先に済ませないと、デプロイしても起動しないAPIが公開されるだけになる。
+3. **バックエンドをデプロイする**。`main` への push で自動実行される（`task deploy:backend` でも可）。
+   デプロイ後に確定した本番URLで `/health` が 200 を返すことを確認する。
+4. **`VITE_API_BASE_URL` を切り替える**。現在は `http://localhost:8080` のままなので、
+   3 で確定したURLに更新する（[フロントエンドの接続先を切り替える](#フロントエンドの接続先を切り替える)）。
+5. **フロントエンドを再デプロイする**。`VITE_API_BASE_URL` はビルド時に埋め込まれるため、
+   変数を変えるだけでは反映されない。
+
 ## 既知の課題
 
 ### 起動時マイグレーションがコールドスタートのたびに走る
@@ -189,7 +209,9 @@ MVP はテーブルが `scores` ひとつだけで `AutoMigrate` は冪等に働
 ### 設定不備がクラッシュループになる
 
 `main.go` は `DATABASE_URL` が未設定だと `log.Fatal` で終了する。
-このときHTTPエラーは返らず、コンテナが起動しては落ちるだけになる。
+このときHTTPエラーは返らず、コンテナが起動しては落ちるだけになると考えられる
+（未デプロイのため未検証。コンテナ起動の時点で失敗する可能性もあるが、
+いずれにせよAPIが応答しない状態になる）。
 HTTPレベルでは Worker がコンテナへ接続できないエラーとして現れるため、
 `/health` の 503（DBには到達できるが疎通に失敗した状態）とは別物であることに注意する。
 

--- a/docs/backend-deploy.md
+++ b/docs/backend-deploy.md
@@ -22,18 +22,48 @@ Worker は薄い中継役で、ルーティングやCORSは従来どおり Gin �
 ブラウザの `Origin` ヘッダーは Worker を素通りして Gin に届くため、
 既存の `CORS_ALLOW_ORIGINS` の仕組みがそのまま機能する。
 
-### なぜ Hyperdrive を使わないのか
+### なぜ Hyperdrive や D1 を使わないのか
 
-[Hyperdrive](https://developers.cloudflare.com/hyperdrive/) は **Worker のバインディング**であり、
-`env.HYPERDRIVE.connectionString` として Worker の JS ランタイム内でだけ有効な接続文字列を発行する。
-コンテナの中で動く Go プロセスは Worker とは別プロセス・別のネットワーク境界にいるため、
-このバインディングには到達できない。
+[Hyperdrive](https://developers.cloudflare.com/hyperdrive/) も [D1](https://developers.cloudflare.com/d1/) も
+**Worker のバインディング**として提供される。バインディングは Worker の JS ランタイム内でのみ有効で、
+SQL のワイヤプロトコルを喋るものではない。
 
-したがって Go の pgx はマネージドPostgresへ**直接TLS接続**する。
-接続プールは Go 側（`database/sql` の `SetMaxOpenConns` など）で管理する必要がある。
+コンテナからバインディングを使う手段自体は存在する
+（[Outbound Workers](https://developers.cloudflare.com/containers/platform-details/outbound-traffic/)。
+コンテナからの HTTP リクエストを Worker 側のハンドラで受け、`env` 経由でバインディングを叩く）。
+ただしその場合、**クエリを実行するのは Worker 側の JavaScript** になり、
+コンテナの Go が受け取るのは JSON である。つまり **GORM が使えなくなる**。
 
-Hyperdrive が効くのは「Worker 内で JS のドライバから直接クエリする」構成のときだけで、
-そのためには Go のバックエンドを Worker に書き直すことになる。
+そのため本構成では Go の pgx がマネージドPostgresへ**直接TLS接続**する。
+接続プールは Go 側（`database/sql` の `SetMaxOpenConns` など）で管理する。
+
+判断の詳細は [DBの選定](#dbの選定) を参照。
+
+### DBの選定
+
+「full Cloudflare 構成にするため D1（SQLite）を使えないか」を検討した結果、
+**マネージドPostgres を採用した**。
+
+前提として、**D1 は SQLite ファイルとしては開けない**。バインディングか HTTP API 経由でしか
+アクセスできないため、`gorm.io/driver/sqlite` では到達できない。
+
+| 案 | DBへの到達手段 | GORM | 判断 |
+| --- | --- | --- | --- |
+| **A（採用）** | pgx で Postgres へ直接TLS接続 | **維持** | 追加コストなし |
+| B′ | Outbound Worker → D1 バインディング | 破棄 | 下記の作り直しが発生 |
+| C | Worker から D1 バインディング（Goをやめる） | Go ごと破棄 | API全書き直し |
+
+B′ は同一マシン内のホップで済み、APIトークンをコンテナに置かなくてよい利点がある。
+しかし repository 層の書き直しに加えて、`AutoMigrate` から `wrangler d1 migrations` への移行、
+`database.Ping` と `/health` の作り直し、`ContainerProxy` の export が必要になる。
+`backend/README.md` が掲げる「Go でレイヤードアーキテクチャ」という前提とも合わない。
+
+得られるものがマネージドPostgres 1契約分の削減にとどまるため、A を選んだ。
+
+> [!NOTE]
+> B′ に将来的に移る場合、`outboundByHost` が `wrangler dev` のローカル D1 バインディングに対して
+> 機能するかを先に確認すること。動かない場合、
+> [ローカルで本番構成を再現する](#ローカルで本番構成を再現する)の手順が使えなくなる。
 
 ## デプロイの種類
 

--- a/docs/backend-deploy.md
+++ b/docs/backend-deploy.md
@@ -1,0 +1,160 @@
+# バックエンドのデプロイ
+
+バックエンドは [Cloudflare Containers](https://developers.cloudflare.com/containers/) で配信する。
+Go の API サーバーをコンテナとして動かし、その前段に置いた Worker がリクエストを中継する。
+
+設定は `backend/wrangler.jsonc`、Worker シムは `backend/worker/index.ts`、
+コンテナイメージは `backend/Dockerfile`、ワークフローは `.github/workflows/deploy-backend.yml`。
+
+## 構成
+
+```text
+ブラウザ
+   ↓ HTTPS
+Worker（backend/worker/index.ts）
+   ↓ getRandom で複数インスタンスに分散
+Container（backend/Dockerfile / Gin + GORM）
+   ↓ TLS
+マネージドPostgres
+```
+
+Worker は薄い中継役で、ルーティングやCORSは従来どおり Gin 側が担当する。
+ブラウザの `Origin` ヘッダーは Worker を素通りして Gin に届くため、
+既存の `CORS_ALLOW_ORIGINS` の仕組みがそのまま機能する。
+
+### なぜ Hyperdrive を使わないのか
+
+[Hyperdrive](https://developers.cloudflare.com/hyperdrive/) は **Worker のバインディング**であり、
+`env.HYPERDRIVE.connectionString` として Worker の JS ランタイム内でだけ有効な接続文字列を発行する。
+コンテナの中で動く Go プロセスは Worker とは別プロセス・別のネットワーク境界にいるため、
+このバインディングには到達できない。
+
+したがって Go の pgx はマネージドPostgresへ**直接TLS接続**する。
+接続プールは Go 側（`database/sql` の `SetMaxOpenConns` など）で管理する必要がある。
+
+Hyperdrive が効くのは「Worker 内で JS のドライバから直接クエリする」構成のときだけで、
+そのためには Go のバックエンドを Worker に書き直すことになる。
+
+## デプロイの種類
+
+| 種類 | トリガー | コマンド | 公開先 |
+| --- | --- | --- | --- |
+| プレビュー | `backend/**` を変更した Pull Request | `wrangler versions upload` | [Preview URL](https://developers.cloudflare.com/workers/versions-and-deployments/preview-urls/)（`https://<バージョン>-wip-backend.uozumi05.workers.dev`） |
+| 本番 | `main` への push | `wrangler deploy` | https://wip-backend.uozumi05.workers.dev |
+
+`versions upload` は新しいバージョンをアップロードするだけで、本番トラフィックの向き先は変更しない。
+プレビューURLは PR に自動でコメントされる。
+
+## 事前に必要な設定
+
+### Cloudflare プラン
+
+Containers は **Workers Paid プラン（月$5〜）** が必要。Free プランでは `wrangler deploy` が失敗する。
+
+### GitHub Secrets
+
+フロントエンドと同じものを流用する（`.github/workflows/deploy-frontend.yml` と共通）。
+
+| 名前 | 内容 |
+| --- | --- |
+| `CLOUDFLARE_API_TOKEN` | Cloudflare の API トークン。**Workers Scripts: Edit** に加え、コンテナイメージを push するため **Containers: Edit** が必要 |
+| `CLOUDFLARE_ACCOUNT_ID` | Cloudflare のアカウントID |
+
+### Cloudflare 側のシークレット
+
+`DATABASE_URL` は機密情報なので `wrangler.jsonc` の `vars` には書かず、Worker Secret として登録する。
+
+```bash
+cd backend
+npx wrangler secret put DATABASE_URL
+# プロンプトに接続文字列を貼り付ける
+# 例: postgres://USER:PASSWORD@HOST/DB?sslmode=require
+```
+
+登録した値は `backend/worker/index.ts` の `envVars` 経由でコンテナへ渡される。
+
+> [!IMPORTANT]
+> 本番用のマネージドPostgres自体はまだ用意していない（Issue #28）。
+> `DATABASE_URL` を登録するまで、デプロイしたAPIの `/health` は 503 を返す。
+
+非機密の `CORS_ALLOW_ORIGINS` は `backend/wrangler.jsonc` の `vars` に直接書いている。
+フロントエンドのオリジンを変える場合はここを編集する。
+
+## フロントエンドの接続先を切り替える
+
+GitHub リポジトリの Settings > Secrets and variables > Actions > Variables で
+`VITE_API_BASE_URL` をバックエンドの本番URLに変更する。
+
+```
+VITE_API_BASE_URL=https://wip-backend.uozumi05.workers.dev
+```
+
+この値はビルド時にバンドルへ埋め込まれるため、変更後はフロントエンドの再デプロイが必要。
+`main` に push するか、`task deploy:frontend` を実行する。
+
+## ローカルからのデプロイ
+
+```bash
+task deploy:backend          # 本番へデプロイ
+task deploy:backend:preview  # プレビュー版をアップロード
+```
+
+初回は `npx wrangler login` で Cloudflare にログインしておく。
+
+> [!NOTE]
+> `wrangler deploy` はコンテナイメージをローカルでビルドして push するため、
+> **Docker が起動している必要がある**。`docker info` で確認できる。
+
+## コンテナの設定
+
+`backend/wrangler.jsonc` の主な項目。
+
+| 項目 | 値 | 理由 |
+| --- | --- | --- |
+| `instance_type` | `basic`（1/4 vCPU・1GiB・4GB） | `lite` の 256MiB は Gin + GORM + pgx にはやや窮屈なため |
+| `max_instances` | `2` | `worker/index.ts` の `INSTANCE_COUNT` と揃える |
+| `sleepAfter` | `5m`（`worker/index.ts`） | アイドル時に停止して課金を抑える |
+
+`sleepAfter` の時間だけリクエストが無いとコンテナは停止する。停止中は課金されないが、
+次のリクエストはコールドスタート（Goの起動 + Postgresへの TCP/TLS ハンドシェイク）を待つ。
+
+## ローカルでコンテナを検証する
+
+`wrangler deploy` を通さずに、イメージ単体の動作を確認できる。
+
+```bash
+task db:up   # ローカルPostgresを起動
+
+cd backend
+docker build --platform linux/amd64 -t wip-backend:test .
+docker run --rm --platform linux/amd64 -p 18099:8080 \
+  -e DATABASE_URL="postgres://wip:wip_password@host.docker.internal:5432/wip?sslmode=disable" \
+  -e CORS_ALLOW_ORIGINS="http://localhost:5173" \
+  wip-backend:test
+
+curl -i http://localhost:18099/health
+```
+
+ホスト側のポートは空いていれば何でもよい。コンテナ側は `8080` 固定
+（`Dockerfile` の `EXPOSE` と `worker/index.ts` の `defaultPort` を揃えてある）。
+
+## 既知の課題
+
+### 起動時マイグレーションがコールドスタートのたびに走る
+
+`backend/cmd/server/main.go` は起動時に `database.Migrate`（GORM の `AutoMigrate`）を実行する。
+Containers はゼロスケールするため、これは**コンテナが起動するたび**に走る。
+さらに複数インスタンスが同時に起動すると、マイグレーションが並行実行される。
+
+MVP はテーブルが `scores` ひとつだけで `AutoMigrate` は冪等に働くため実害は小さいが、
+テーブルが増えたら以下のいずれかへ移行する。
+
+- `RUN_MIGRATIONS` のような環境変数で実行を制御し、本番は別経路で流す
+- golang-migrate などのマイグレーションツールを導入し、デプロイ前の単発ジョブにする
+
+### 設定不備がクラッシュループになる
+
+`main.go` は `DATABASE_URL` が未設定だと `log.Fatal` で終了する。
+このときHTTPエラーは返らず、コンテナが起動しては落ちるだけになる。
+原因は Cloudflare ダッシュボードの Workers > wip-backend > Logs、
+または `npx wrangler tail` で確認する。

--- a/docs/backend-deploy.md
+++ b/docs/backend-deploy.md
@@ -69,7 +69,7 @@ B′ は同一マシン内のホップで済み、APIトークンをコンテナ
 
 | 種類 | トリガー | コマンド | 公開先 |
 | --- | --- | --- | --- |
-| 本番 | `main` への push | `wrangler deploy` | `https://wip-backend.uozumi05.workers.dev`（想定。初回デプロイ後に確定する） |
+| 本番 | `main` への push | `wrangler deploy` | https://wip-backend.uozumi05.workers.dev |
 
 ### プレビューデプロイが無い理由
 
@@ -114,10 +114,11 @@ npx wrangler secret put DATABASE_URL
 登録した値は `backend/worker/index.ts` の `envVars` 経由でコンテナへ渡される。
 
 > [!IMPORTANT]
-> 本番用のマネージドPostgres自体はまだ用意していない（Issue #28）。
-> `DATABASE_URL` を登録するまでコンテナは起動に失敗し続ける（後述の
+> `DATABASE_URL` を登録しないままデプロイすると、コンテナは起動に失敗し続ける（後述の
 > [設定不備がクラッシュループになる](#設定不備がクラッシュループになる)）。
 > `/health` が 503 を返すのではなく、そもそもAPIが応答しない点に注意する。
+> 接続先には**外部から到達できるマネージドPostgres**を指定すること。
+> ローカル用の値（`localhost` や `host.docker.internal`）はコンテナから解決できない。
 
 非機密の `CORS_ALLOW_ORIGINS` は `backend/wrangler.jsonc` の `vars` に直接書いている。
 フロントエンドのオリジンを変える場合はここを編集する。
@@ -209,18 +210,18 @@ curl -i http://localhost:18099/health
 
 ## 残作業
 
-デプロイの仕組みは用意したが、**まだ一度もデプロイしていない**。
-本番を動かすには以下を順に進める。各手順が次の手順の前提になっている。
-
-1. **マネージドPostgresを用意する**（Issue #28）。接続文字列を入手する。
-2. **`DATABASE_URL` を登録する**。`cd backend && npx wrangler secret put DATABASE_URL`。
-   これを先に済ませないと、デプロイしても起動しないAPIが公開されるだけになる。
-3. **バックエンドをデプロイする**。`main` への push で自動実行される（`task deploy:backend` でも可）。
-   デプロイ後に確定した本番URLで `/health` が 200 を返すことを確認する。
-4. **`VITE_API_BASE_URL` を切り替える**。現在は `http://localhost:8080` のままなので、
-   3 で確定したURLに更新する（[フロントエンドの接続先を切り替える](#フロントエンドの接続先を切り替える)）。
-5. **フロントエンドを再デプロイする**。`VITE_API_BASE_URL` はビルド時に埋め込まれるため、
+1. **バックエンドをデプロイする**。`main` への push で自動実行される（`task deploy:backend` でも可）。
+   `/health` が 200 を返すことを確認する。
+2. **`VITE_API_BASE_URL` を切り替える**。現在は `http://localhost:8080` のままなので、
+   本番URLに更新する（[フロントエンドの接続先を切り替える](#フロントエンドの接続先を切り替える)）。
+3. **フロントエンドを再デプロイする**。`VITE_API_BASE_URL` はビルド時に埋め込まれるため、
    変数を変えるだけでは反映されない。
+
+> [!NOTE]
+> `wrangler deploy` を一度も実行していない状態で `wrangler secret put` を実行すると、
+> **中身のないプレースホルダWorkerが自動生成される**。この状態では
+> `wip-backend.uozumi05.workers.dev` は 404 を返し、`wrangler containers list` にも何も出ない。
+> 設定ミスではなく、初回デプロイで解消する。登録済みのシークレットはデプロイをまたいで保持される。
 
 ## 既知の課題
 


### PR DESCRIPTION
## 概要

Go の API サーバーを [Cloudflare Containers](https://developers.cloudflare.com/containers/) で動かすデプロイ基盤を整備しました。
コンテナの前段に薄い Worker を置いて中継する構成です。

```text
ブラウザ → Worker（中継） → Container（Gin + GORM） → マネージドPostgres
```

Closes #14

## 変更内容

| ファイル | 内容 |
| --- | --- |
| `backend/Dockerfile` | distroless ベースの静的バイナリ（**10.3MB** / linux-amd64） |
| `backend/worker/index.ts` | `getRandom` でステートレスに分散する Worker シム |
| `backend/wrangler.jsonc` | `instance_type=basic`、`DATABASE_URL` は Worker Secret |
| `.github/workflows/deploy-backend.yml` | `main` への push で本番デプロイ |
| `.github/workflows/quality.yml` | Worker シムの型検査ジョブを追加 |
| `Taskfile.yml` | `deploy:backend` / `dev:backend:container` を追加 |
| `docs/backend-deploy.md` | 手順・構成・DB選定の判断・既知の課題 |

Go 側のコードは変更していません。

## 検証したこと

`wrangler dev` で **Worker → コンテナ → Postgres を実際に通して確認**しました。

- `/health` が 200（DB疎通込み）
- `POST /api/scores` が 201、`GET /api/rankings` が 200
- CORS が許可オリジンを通し、それ以外を 403 で拒否
- `getRandom` が2インスタンスに分散（ログで `backend container started` が2回）
- ドキュメント記載のコマンドが記載どおりに動くこと

## 設計判断

### プレビューデプロイは用意していません

フロントエンドから流用しようとしましたが、[ドキュメント](https://developers.cloudflare.com/containers/deploy/)に次の記載があり機能しないため削除しました。

- Preview URL は **Durable Object を持つ Worker には発行されない**（Containers Worker が該当）
- `wrangler versions upload` は**コンテナイメージの publish もロールアウトも行わない**

代わりに `task dev:backend:container`（`wrangler dev`）でのローカル検証手順を用意しています。

### DBはマネージドPostgres（D1は不採用）

「full Cloudflare 構成にするため D1（SQLite）を使えないか」を検討しましたが、**D1 は SQLite ファイルとして開けない**ため `gorm.io/driver/sqlite` では到達できません。

[Outbound Workers](https://developers.cloudflare.com/containers/platform-details/outbound-traffic/) を使えばコンテナからバインディングに到達する手段はありますが、クエリを実行するのは Worker 側の JavaScript になるため **GORM が使えなくなります**。

得られるものがマネージドPostgres 1契約分の削減にとどまるため、Go + GORM を維持する現構成を採用しました。判断の詳細は `docs/backend-deploy.md` の「DBの選定」に記録しています。

## マージ後について

`DATABASE_URL` は登録済みです。マージすると `deploy-backend.yml` が走り、イメージの publish とコンテナのロールアウトが実行されます。

> [!NOTE]
> 現在 https://wip-backend.uozumi05.workers.dev は **404 を返します**。
> `wrangler deploy` 前に `wrangler secret put` を実行したため、中身のないプレースホルダ Worker が自動生成された状態です（`wrangler containers list` も空）。設定ミスではなく、初回デプロイで解消します。
> 同じ理由で、初回デプロイ時に `migrations` の `v1` タグ適用でエラーが出た場合も、プレースホルダ Worker に DO クラスが無いことが原因で設定不備ではありません。

マージ後の残作業（`docs/backend-deploy.md` にも記載）：

1. `/health` が 200 を返すことを確認
2. リポジトリ変数 `VITE_API_BASE_URL` を本番URLに更新（現在 `http://localhost:8080`）
3. フロントエンドを再デプロイ（ビルド時に埋め込まれるため変数変更だけでは反映されない）

## 既知の課題（別Issue化を想定）

- **起動時マイグレーションがコールドスタートのたびに走る**。Containers はゼロスケールするため `AutoMigrate` が毎回実行され、同時起動時は並行実行されます。テーブルが `scores` 1つで冪等に働くため実害は小さいですが、テーブルが増える前に移行が必要です。
- **設定不備がクラッシュループになる**。`main.go` は `DATABASE_URL` 未設定時に `log.Fatal` で終了するため、HTTPエラーではなくコンテナの起動失敗として現れます。
