### PR TITLE
WIP: Workers AI TTS の検証

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -137,6 +137,24 @@ task dev:backend:container     # Worker＋コンテナをローカルで起動
 
 `main` への push で自動デプロイされるため、通常は手動実行は不要。
 
+## Workers AI 音声生成
+
+`POST /ai/speech` に日本語テキストを送ると、Workers AI の
+`@cf/myshell-ai/melotts` を使って WAV 音声を返す。
+
+```bash
+curl -X POST https://api.uomi.dev/ai/speech \
+  -H 'Content-Type: application/json' \
+  -d '{"text":"こんにちは。Workers AIで生成した音声です。"}' \
+  --output speech.mp3
+```
+
+ローカルでAI推論を確認する際は、Cloudflare上の推論を使うため以下を実行する。
+
+```bash
+npm run dev -- --remote
+```
+
 ## 目的
 
 - ゲームのスコアを保存する

--- a/backend/worker/app.test.ts
+++ b/backend/worker/app.test.ts
@@ -7,6 +7,56 @@ const env = {
 } as unknown as Env;
 
 describe("createApp", () => {
+  it("generates Japanese speech as a WAV response", async () => {
+    const ai = {
+      run: vi.fn().mockResolvedValue({ audio: "YXVkaW8gYnl0ZXM=" }),
+    } as unknown as Ai;
+    const fetchContainer = vi.fn();
+    const app = createApp(fetchContainer);
+
+    const response = await app.request(
+      "https://api.example/ai/speech",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text: "こんにちは、Workers AIです。" }),
+      },
+      { ...env, AI: ai },
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("audio/wav");
+    await expect(response.text()).resolves.toBe("audio bytes");
+    expect(ai.run).toHaveBeenCalledWith(
+      "@cf/myshell-ai/melotts",
+      { prompt: "こんにちは、Workers AIです。", lang: "ja" },
+    );
+    expect(fetchContainer).not.toHaveBeenCalled();
+  });
+
+  it("retries speech generation once after a transient Workers AI failure", async () => {
+    const ai = {
+      run: vi
+        .fn()
+        .mockRejectedValueOnce(new Error("upstream unavailable"))
+        .mockResolvedValueOnce({ audio: "YXVkaW8gYnl0ZXM=" }),
+    } as unknown as Ai;
+    const app = createApp(vi.fn());
+
+    const response = await app.request(
+      "https://api.example/ai/speech",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text: "もう一度試します。" }),
+      },
+      { ...env, AI: ai },
+    );
+
+    expect(response.status).toBe(200);
+    expect(ai.run).toHaveBeenCalledTimes(2);
+  });
+
   it("answers an allowed AI preflight request without forwarding it to the container", async () => {
     const fetchContainer = vi.fn();
     const app = createApp(fetchContainer);

--- a/backend/worker/app.ts
+++ b/backend/worker/app.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { cors } from "hono/cors";
 
+import { createSpeech } from "./speech";
 import { createTaunt } from "./taunt";
 
 type FetchContainer = (request: Request, env: Env) => Promise<Response>;
@@ -27,6 +28,7 @@ export function createApp(fetchContainer: FetchContainer) {
   // preflightをContainerへ流さずここで終端する。
   app.options("/ai/*", (c) => c.body(null, 204));
   app.post("/ai/taunt", (c) => createTaunt(c.req.raw, c.env.AI));
+  app.post("/ai/speech", (c) => createSpeech(c.req.raw, c.env.AI));
   
   // /ai/* 以外のリクエストは、コンテナに転送する
   app.all("*", (c) => fetchContainer(c.req.raw, c.env));

--- a/backend/worker/speech.ts
+++ b/backend/worker/speech.ts
@@ -1,0 +1,46 @@
+const MODEL = "@cf/myshell-ai/melotts";
+
+function hasAudio(value: unknown): value is { audio: string } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "audio" in value &&
+    typeof value.audio === "string"
+  );
+}
+
+export async function createSpeech(request: Request, ai: Ai): Promise<Response> {
+  let body: { text?: unknown };
+
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: "JSON形式の本文を指定してください。" }, { status: 400 });
+  }
+
+  if (typeof body.text !== "string" || body.text.trim() === "") {
+    return Response.json({ error: "textには空でない文字列を指定してください。" }, { status: 400 });
+  }
+
+  let result: unknown;
+  try {
+    result = await ai.run(MODEL, { prompt: body.text, lang: "ja" });
+  } catch {
+    try {
+      result = await ai.run(MODEL, { prompt: body.text, lang: "ja" });
+    } catch {
+      return Response.json(
+        { error: "音声生成サービスが一時的に利用できません。" },
+        { status: 503 },
+      );
+    }
+  }
+
+  if (!hasAudio(result)) {
+    throw new Error("Workers AI returned an unexpected speech response.");
+  }
+
+  const binary = atob(result.audio);
+  const audio = Uint8Array.from(binary, (character) => character.charCodeAt(0));
+  return new Response(audio, { headers: { "Content-Type": "audio/wav" } });
+}

--- a/frontend/src/game/VRGameScene.tsx
+++ b/frontend/src/game/VRGameScene.tsx
@@ -57,6 +57,7 @@ import VRBattleHUD from "./VRBattleHUD";
 import CreditsScene from "./CreditsScene";
 import { CREDIT_PUNCH_SFX_PATH, CREDIT_PUNCH_SFX_VOLUME } from "./credits";
 import VRTutorial from "./VRTutorial";
+import { requestSpeech } from "./speechClient";
 import { requestTaunt } from "./tauntClient";
 import {
   pendingTauntForEnemy,
@@ -588,6 +589,7 @@ function VRGameLoop({
   onPlayerHit,
   onSwing,
   onEnemyShoot,
+  onTauntSpoken,
   desktopDebug,
 }: {
   onStateChange: (enemy: Enemy, combo: ComboState, playerHp: number, phase: BattlePhase) => void;
@@ -597,6 +599,7 @@ function VRGameLoop({
   onPlayerHit: () => void;
   onSwing: () => void;
   onEnemyShoot: () => void;
+  onTauntSpoken: (phrase: string) => void;
   desktopDebug: boolean;
 }) {
   const [enemy, setEnemy] = useState<Enemy>(createEnemy);
@@ -881,8 +884,9 @@ function VRGameLoop({
       if (!shouldDisplayTaunt(activeEnemyIdRef.current, enemy.id)) return;
       tauntHistoryRef.current = [phrase, ...tauntHistoryRef.current].slice(0, 3);
       setTaunt({ enemyId: enemy.id, phrase });
+      onTauntSpoken(phrase);
     });
-  }, [enemy.id, enemy.isBoss, playerHp]);
+  }, [enemy.id, enemy.isBoss, onTauntSpoken, playerHp]);
 
   return (
     <>
@@ -950,6 +954,8 @@ export default function VRGameScene({ desktopDebug = false }: { desktopDebug?: b
   const punchSfxRef = useRef<HTMLAudioElement>(null);
   const swingSfxRef = useRef<HTMLAudioElement>(null);
   const enemyShootSfxRef = useRef<HTMLAudioElement>(null);
+  const tauntSpeechRef = useRef<HTMLAudioElement>(null);
+  const tauntSpeechUrlRef = useRef<string | null>(null);
   const [showTutorial, setShowTutorial] = useState(true);
 
   // "battle": ターン制バトル / "credits": DV撃破後のエンドロール。
@@ -1032,6 +1038,29 @@ export default function VRGameScene({ desktopDebug = false }: { desktopDebug?: b
     });
   }
 
+  function playTauntSpeech(phrase: string) {
+    void requestSpeech(phrase).then((audioBlob) => {
+      const audio = tauntSpeechRef.current;
+      if (!audioBlob || !audio) return;
+
+      if (tauntSpeechUrlRef.current) URL.revokeObjectURL(tauntSpeechUrlRef.current);
+      const url = URL.createObjectURL(audioBlob);
+      tauntSpeechUrlRef.current = url;
+      audio.src = url;
+      audio.currentTime = 0;
+      audio.volume = 0.8;
+      audio.play().catch(() => {
+        // ブラウザの自動再生制限や推論失敗時もゲーム進行は止めない。
+      });
+    });
+  }
+
+  useEffect(() => {
+    return () => {
+      if (tauntSpeechUrlRef.current) URL.revokeObjectURL(tauntSpeechUrlRef.current);
+    };
+  }, []);
+
   // VRセッションを張ったままナビゲートすると、ヘッドセット側の表示がこのCanvasの
   // 最終フレームで止まり /result のスコアが見えなくなる。先にセッションを終了して
   // 通常の2D画面へ戻してから遷移する。
@@ -1050,6 +1079,7 @@ export default function VRGameScene({ desktopDebug = false }: { desktopDebug?: b
       <audio ref={punchSfxRef} src={CREDIT_PUNCH_SFX_PATH} preload="auto" />
       <audio ref={swingSfxRef} src={SWING_SFX_PATH} preload="auto" />
       <audio ref={enemyShootSfxRef} src={ENEMY_SHOOT_SFX_PATH} preload="auto" />
+      <audio ref={tauntSpeechRef} preload="none" />
       {desktopDebug ? (
         <div className="font-display absolute top-4 left-1/2 z-10 -translate-x-1/2 border border-emerald-400/50 bg-slate-950/80 px-5 py-2 text-xs tracking-[0.2em] text-emerald-200">
           DESKTOP VR DEBUG
@@ -1094,6 +1124,7 @@ export default function VRGameScene({ desktopDebug = false }: { desktopDebug?: b
                         onPlayerHit={playPlayerHitSfx}
                         onSwing={playSwingSfx}
                         onEnemyShoot={playEnemyShootSfx}
+                        onTauntSpoken={playTauntSpeech}
                         desktopDebug={desktopDebug}
                         onGameOver={(score, result) => {
                           if (result === "clear") {

--- a/frontend/src/game/speechClient.test.ts
+++ b/frontend/src/game/speechClient.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { requestSpeech, speechEndpoint } from "./speechClient";
+
+describe("requestSpeech", () => {
+  it("sends the taunt text to the speech endpoint and returns its MP3 blob", async () => {
+    const audio = new Blob(["audio bytes"], { type: "audio/mpeg" });
+    const fetchImplementation = vi.fn().mockResolvedValue(new Response(audio, { status: 200 }));
+
+    await expect(requestSpeech("休んでいきな？", fetchImplementation)).resolves.toEqual(audio);
+
+    expect(fetchImplementation).toHaveBeenCalledWith(
+      "/ai/speech",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ text: "休んでいきな？" }),
+      },
+    );
+  });
+
+  it("uses Vite's same-origin proxy during local development", () => {
+    expect(speechEndpoint(true)).toBe("/ai/speech");
+  });
+
+  it("returns null when speech generation is unavailable", async () => {
+    const fetchImplementation = vi.fn().mockRejectedValue(new Error("offline"));
+
+    await expect(requestSpeech("休んでいきな？", fetchImplementation)).resolves.toBeNull();
+  });
+});

--- a/frontend/src/game/speechClient.ts
+++ b/frontend/src/game/speechClient.ts
@@ -1,0 +1,20 @@
+export function speechEndpoint(isDevelopment = import.meta.env.DEV): string {
+  const baseUrl = isDevelopment ? "" : (import.meta.env.VITE_API_BASE_URL ?? "");
+  return `${baseUrl}/ai/speech`;
+}
+
+export async function requestSpeech(
+  text: string,
+  fetchImplementation: typeof fetch = fetch,
+): Promise<Blob | null> {
+  try {
+    const response = await fetchImplementation(speechEndpoint(), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ text }),
+    });
+    return response.ok ? response.blob() : null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## 目的

Workers AI の `@cf/myshell-ai/melotts` を VR の敵台詞に接続した検証を、採用しない前提の記録として残します。

> **DO NOT MERGE** — 音声機能は見送ります。

## 実測結果

- `InferenceUpstreamError (3043)` と `503 Service Unavailable` が断続的に発生し、成功率が実用水準に届きませんでした。
- 日本語の読み上げ品質も用途に合いませんでした。

## レビューで確認した未解決事項

- 非同期応答が遅れた場合、既に入れ替わった敵の古い台詞が再生される可能性があります。
- 公開エンドポイントに入力長制限・レート制限がなく、推論リソースを消費され得ます。
- レスポンスは WAV なのに README とテスト名の一部が MP3 表記です。即時リトライも上流障害時の負荷を増やします。

## 確認済み

- `backend`: `npm run typecheck && npm test`
- `frontend`: `npm run build && npm test`

採用しない決定と検証内容を追跡できるよう、Draft のまま保持します。